### PR TITLE
Modified POST content type check to allow for parameter specification

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -73,7 +73,7 @@ class Request implements RequestInterface
             $requestMethod = $this->params['REQUEST_METHOD'];
             $contentType   = $this->params['CONTENT_TYPE'];
 
-            if (strcasecmp($requestMethod, 'POST') === 0 && strcasecmp($contentType, 'application/x-www-form-urlencoded') === 0) {
+            if (strcasecmp($requestMethod, 'POST') === 0 && stripos($contentType, 'application/x-www-form-urlencoded') === 0) {
                 $postData = stream_get_contents($this->stdin);
                 rewind($this->stdin);
 


### PR DESCRIPTION
If you take a look at the [Content-Type spec](http://www.w3.org/Protocols/rfc1341/4_Content-Type.html), you can see that there is a possible list of parameters that comes after the type/subtype definition: `Content-Type := type "/" subtype *[";" parameter] ` 

This patch allows for these additional parameters, only ensuring that the first part of the content-type is "application/x-www-form-urlencoded".