### PR TITLE
Add param for custom file descriptor

### DIFF
--- a/src/Command/DaemonRunCommand.php
+++ b/src/Command/DaemonRunCommand.php
@@ -2,6 +2,7 @@
 
 namespace PHPFastCGI\FastCGIDaemon\Command;
 
+use PHPFastCGI\FastCGIDaemon\DaemonInterface;
 use PHPFastCGI\FastCGIDaemon\DaemonOptions;
 use PHPFastCGI\FastCGIDaemon\Driver\DriverContainerInterface;
 use PHPFastCGI\FastCGIDaemon\KernelInterface;
@@ -48,6 +49,7 @@ class DaemonRunCommand extends Command
             ->setDescription($description)
             ->addOption('port',          null, InputOption::VALUE_OPTIONAL, 'TCP port to listen on (if not present, daemon will listen on FCGI_LISTENSOCK_FILENO)')
             ->addOption('host',          null, InputOption::VALUE_OPTIONAL, 'TCP host to listen on')
+            ->addOption('fd',            null, InputOption::VALUE_OPTIONAL, 'File descriptor to listen on - defaults to FCGI_LISTENSOCK_FILENO', DaemonInterface::FCGI_LISTENSOCK_FILENO)
             ->addOption('request-limit', null, InputOption::VALUE_OPTIONAL, 'The maximum number of requests to handle before shutting down')
             ->addOption('memory-limit',  null, InputOption::VALUE_OPTIONAL, 'The memory limit on the daemon instance before shutting down')
             ->addOption('time-limit',    null, InputOption::VALUE_OPTIONAL, 'The time limit on the daemon in seconds before shutting down')
@@ -86,6 +88,7 @@ class DaemonRunCommand extends Command
     {
         $port = $input->getOption('port');
         $host = $input->getOption('host');
+        $fd = $input->getOption('fd');
 
         $daemonOptions = $this->getDaemonOptions($input, $output);
 
@@ -100,7 +103,7 @@ class DaemonRunCommand extends Command
             throw new \InvalidArgumentException('TCP port option must be set if host option is set');
         } else {
             // With no host or port, listen on FCGI_LISTENSOCK_FILENO (default)
-            $daemon = $daemonFactory->createDaemon($this->kernel, $daemonOptions);
+            $daemon = $daemonFactory->createDaemon($this->kernel, $daemonOptions, $fd);
         }
 
         $daemon->run();

--- a/src/DaemonFactoryInterface.php
+++ b/src/DaemonFactoryInterface.php
@@ -10,14 +10,15 @@ namespace PHPFastCGI\FastCGIDaemon;
 interface DaemonFactoryInterface
 {
     /**
-     * Create a FastCGI daemon listening on FCGI_LISTENSOCK_FILENO.
+     * Create a FastCGI daemon listening on file descriptor.
      *
-     * @param KernelInterface        $kernel  The kernel to use for the daemon
-     * @param DaemonOptionsInterface $options The daemon configuration
+     * @param KernelInterface $kernel The kernel to use for the daemon
+     * @param DaemonOptions|DaemonOptionsInterface $options The daemon configuration
+     * @param int $fd file descriptor for listening defaults to FCGI_LISTENSOCK_FILENO
      *
      * @return DaemonInterface The FastCGI daemon
      */
-    public function createDaemon(KernelInterface $kernel, DaemonOptions $options);
+    public function createDaemon(KernelInterface $kernel, DaemonOptions $options, $fd = DaemonInterface::FCGI_LISTENSOCK_FILENO);
 
     /**
      * Create a FastCGI daemon listening on a given address. The default host is

--- a/src/Driver/Userland/UserlandDaemonFactory.php
+++ b/src/Driver/Userland/UserlandDaemonFactory.php
@@ -15,22 +15,23 @@ use PHPFastCGI\FastCGIDaemon\KernelInterface;
 class UserlandDaemonFactory implements DaemonFactoryInterface
 {
     /**
-     * Create a FastCGI daemon listening on FCGI_LISTENSOCK_FILENO using the
+     * Create a FastCGI daemon listening on file descriptor using the
      * userland FastCGI implementation.
      *
      * @param KernelInterface $kernel  The kernel to use for the daemon
      * @param DaemonOptions   $options The daemon configuration
+     * @param int $fd file descriptor for listening defaults to FCGI_LISTENSOCK_FILENO
      *
      * @return UserlandDaemon
      *
      * @codeCoverageIgnore The FastCGI daemon
      */
-    public function createDaemon(KernelInterface $kernel, DaemonOptions $options)
+    public function createDaemon(KernelInterface $kernel, DaemonOptions $options, $fd = DaemonInterface::FCGI_LISTENSOCK_FILENO)
     {
-        $socket = fopen('php://fd/'.DaemonInterface::FCGI_LISTENSOCK_FILENO, 'r');
+        $socket = fopen('php://fd/'.$fd, 'r');
 
         if (false === $socket) {
-            throw new \RuntimeException('Could not open FCGI_LISTENSOCK_FILENO');
+            throw new \RuntimeException('Could not open ' . $fd);
         }
 
         return $this->createDaemonFromStreamSocket($kernel, $options, $socket);

--- a/test/Helper/Mocker/MockDaemonFactory.php
+++ b/test/Helper/Mocker/MockDaemonFactory.php
@@ -3,6 +3,7 @@
 namespace PHPFastCGI\Test\FastCGIDaemon\Helper\Mocker;
 
 use PHPFastCGI\FastCGIDaemon\DaemonFactoryInterface;
+use PHPFastCGI\FastCGIDaemon\DaemonInterface;
 use PHPFastCGI\FastCGIDaemon\DaemonOptions;
 use PHPFastCGI\FastCGIDaemon\KernelInterface;
 
@@ -10,7 +11,7 @@ class MockDaemonFactory implements DaemonFactoryInterface
 {
     use MockerTrait;
 
-    public function createDaemon(KernelInterface $kernel, DaemonOptions $options)
+    public function createDaemon(KernelInterface $kernel, DaemonOptions $options, $fd = DaemonInterface::FCGI_LISTENSOCK_FILENO)
     {
         return $this->delegateCall('createDaemon', func_get_args());
     }


### PR DESCRIPTION
Add possibility to pass file descriptor number as command param.

This helps with using process managers like https://circus.readthedocs.io/en/latest/ (where all running deamon processes are children of manager process and share pool of file descriptors)