### PR TITLE
Signal dispatch for graceful quit

### DIFF
--- a/src/DaemonTrait.php
+++ b/src/DaemonTrait.php
@@ -82,6 +82,8 @@ trait DaemonTrait
      */
     private function checkDaemonLimits()
     {
+        pcntl_signal_dispatch();
+
         if (DaemonOptions::NO_LIMIT !== $this->requestLimit) {
             if ($this->requestLimit <= $this->requestCount) {
                 throw new RequestLimitException('Daemon request limit reached ('.$this->requestCount.' of '.$this->requestLimit.')');


### PR DESCRIPTION
I wanted to add graceful shutdown (as in php-fpm reaction for `SIGQUIT` php-fpm workers die after finishing handling current request). While testing I noticed that application does not react to signals other than `SIGKILL` even though handlers are registered.

Signals were causing `sleep()` to be interrupted but server execution was not. This was tested and replicated on PHP 5.5 and PHP 7.0 on OSX and PHP 7.0 on Debian.

After adding additional signal dispatching process gracefully exists after handling current request after receiving either `SIGINT` or `SIGALRM`.

(This is more of an issue with handling signals rather than pull requests, but this achieves what I needed)