### PR TITLE
Support multiple upload files

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -282,19 +282,19 @@ final class Request implements RequestInterface
             'size' => filesize($tmpPath),
         ];
 
-        $matches = preg_split('|(\[[^\]]*\])|', $fieldName, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
-        $count = count($matches);
+        $parts = preg_split('|(\[[^\]]*\])|', $fieldName, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+        $count = count($parts);
         if (1 === $count) {
             $files[$fieldName] = $data;
         } else {
             $current = &$files;
-            foreach ($matches as $i => $match) {
-                if ($match === '[]') {
+            foreach ($parts as $i => $part) {
+                if ($part === '[]') {
                     $current[] = $data;
                     continue;
                 }
 
-                $trimmedMatch = trim($match, '[]');
+                $trimmedMatch = trim($part, '[]');
                 if ($i === $count -1) {
                     $current[$trimmedMatch] = $data;
                 } else {

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -282,21 +282,23 @@ final class Request implements RequestInterface
             'size' => filesize($tmpPath),
         ];
 
-        if (!preg_match('|([^\[]+)(?:\[([^\]]+)\])*(\[\])?|', $fieldName, $matches)) {
+        $matches = preg_split('|(\[[^\]]*\])|', $fieldName, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+        $count = count($matches);
+        if (1 === $count) {
             $files[$fieldName] = $data;
         } else {
             $current = &$files;
-            $count = count($matches);
-            for ($i = 1; $i < $count; $i++) {
-                if (empty($matches[$i])) {
+            foreach ($matches as $i => $match) {
+                if ($match === '[]') {
+                    $current[] = $data;
                     continue;
                 }
-                if ($matches[$i] === '[]') {
-                    $current[] = $data;
-                } elseif ($i === $count -1) {
-                    $current[$matches[$i]] = $data;
+
+                $trimmedMatch = trim($match, '[]');
+                if ($i === $count -1) {
+                    $current[$trimmedMatch] = $data;
                 } else {
-                    $current = &$current[$matches[$i]];
+                    $current = &$current[$trimmedMatch];
                 }
             }
         }

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -166,13 +166,7 @@ final class Request implements RequestInterface
                 } elseif ($fieldType === 'file' && $filename) {
                     $tmpPath = tempnam($this->getUploadDir(), 'fastcgi_upload');
                     $err = file_put_contents($tmpPath, $buffer);
-                    $files[$fieldName] = [
-                        'type' => $mimeType ?: 'application/octet-stream',
-                        'name' => $filename,
-                        'tmp_name' => $tmpPath,
-                        'error' => ($err === false) ? true : 0,
-                        'size' => filesize($tmpPath),
-                    ];
+                    $this->addFile($files, $fieldName, $filename, $tmpPath, $mimeType, false === $err);
                     $filename = $mimeType = null;
                 }
                 $fieldName = $fieldType = null;
@@ -248,10 +242,8 @@ final class Request implements RequestInterface
         $uri     = ServerRequestFactory::marshalUriFromServer($server, $headers);
         $method  = ServerRequestFactory::get('REQUEST_METHOD', $server, 'GET');
 
-        $files = [];
-        foreach ($this->uploadedFiles as $file) {
-            $files[] = createUploadedFile($file);
-        }
+        $files = $this->uploadedFiles;
+        $this->preparePsr7UploadedFiles($files);
 
         $request = new ServerRequest($server, $files, $uri, $method, $this->stdin, $headers);
 
@@ -275,5 +267,49 @@ final class Request implements RequestInterface
         $cookies = $this->getCookies();
 
         return new HttpFoundationRequest($query, $post, [], $cookies, $this->uploadedFiles, $this->params, $this->stdin);
+    }
+
+    /**
+     * Add a file to the $files array
+     */
+    private function addFile(array &$files, string $fieldName, string $filename, string $tmpPath, string $mimeType, bool $err): void
+    {
+        $data = [
+            'type' => $mimeType ?: 'application/octet-stream',
+            'name' => $filename,
+            'tmp_name' => $tmpPath,
+            'error' => $err ? UPLOAD_ERR_CANT_WRITE : UPLOAD_ERR_OK,
+            'size' => filesize($tmpPath),
+        ];
+
+        if (!preg_match('|([^\[]+)(?:\[([^\]]+)\])*(\[\])?|', $fieldName, $matches)) {
+            $files[$fieldName] = $data;
+        } else {
+            $current = &$files;
+            $count = count($matches);
+            for ($i = 1; $i < $count; $i++) {
+                if (empty($matches[$i])) {
+                    continue;
+                }
+                if ($matches[$i] === '[]') {
+                    $current[] = $data;
+                } elseif ($i === $count -1) {
+                    $current[$matches[$i]] = $data;
+                } else {
+                    $current = &$current[$matches[$i]];
+                }
+            }
+        }
+    }
+
+    private function preparePsr7UploadedFiles(array &$files)
+    {
+        if (isset($files['tmp_name'])) {
+            $files = createUploadedFile($files);
+        } else {
+            foreach ($files as &$file) {
+                $this->preparePsr7UploadedFiles($file);
+            }
+        }
     }
 }

--- a/test/Http/RequestTest.php
+++ b/test/Http/RequestTest.php
@@ -192,7 +192,7 @@ Content-Type: image/png
 ???
 IHDR??? ??? ?????? ???? IDATxc???51?)?:??????IEND?B`?
 --578de3b0e3c46.2334ba3
-Content-Disposition: form-data; name="four[item_a][item_b[]"; filename="foo.png"
+Content-Disposition: form-data; name="four[item_a][item_b][]"; filename="foo.png"
 Content-Length: 71
 Content-Type: image/png
 
@@ -200,7 +200,8 @@ Content-Type: image/png
 
 ???
 IHDR??? ??? ?????? ???? IDATxc???51?)?:??????IEND?B`?
-Content-Disposition: form-data; name="four[item_a][item_b[]"; filename="bar.png"
+--578de3b0e3c46.2334ba3
+Content-Disposition: form-data; name="four[item_a][item_b][]"; filename="bar.png"
 Content-Length: 71
 Content-Type: image/png
 
@@ -246,13 +247,13 @@ HTTP;
         $this->assertNotEmpty($files['four']);
         $this->assertNotEmpty($files['four']['item_a']);
         $this->assertNotEmpty($files['four']['item_a']['item_b']);
-        $this->assertCount(2, $files['three']['item_a']['item_b']);
+        $this->assertCount(2, $files['four']['item_a']['item_b']);
 
         // Check the HttpFoundation request
         rewind($stream);
         $httpFoundationRequest = $request->getHttpFoundationRequest();
         $this->assertEquals($expectedPost, $httpFoundationRequest->request->all());
-        $this->assertCount(7,              $httpFoundationRequest->files->all());
+        $this->assertCount(4,              $httpFoundationRequest->files->all());
 
     }
 }

--- a/test/Http/RequestTest.php
+++ b/test/Http/RequestTest.php
@@ -125,4 +125,134 @@ HTTP;
         $this->assertCount(1,              $httpFoundationRequest->files->all());
         $this->assertEquals($content,      $httpFoundationRequest->getContent());
     }
+
+    public function testMultipartContentWithMultipleFiles()
+    {
+        $expectedPost    = ['foo' => 'A normal stream', 'baz' => 'string'];
+
+        // Set up FastCGI params and content
+        $params = [
+            'SERVER_PROTOCOL' => 'HTTP/1.1',
+            'REQUEST_METHOD'  => 'POST',
+            'content_type'    => 'multipart/form-data; boundary="578de3b0e3c46.2334ba3"',
+            'REQUEST_URI'     => '/my-page',
+        ];
+
+        // Set up the FastCGI stdin data stream resource
+        $content = <<<HTTP
+--578de3b0e3c46.2334ba3
+Content-Disposition: form-data; name="foo"
+Content-Length: 15
+
+A normal stream
+--578de3b0e3c46.2334ba3
+Content-Disposition: form-data; name="one[]"; filename="foo.png"
+Content-Length: 71
+Content-Type: image/png
+
+?PNG
+
+???
+IHDR??? ??? ?????? ???? IDATxc???51?)?:??????IEND?B`?
+--578de3b0e3c46.2334ba3
+--578de3b0e3c46.2334ba3
+Content-Disposition: form-data; name="one[]"; filename="bar.png"
+Content-Length: 71
+Content-Type: image/png
+
+?PNG
+
+???
+IHDR??? ??? ?????? ???? IDATxc???51?)?:??????IEND?B`?
+--578de3b0e3c46.2334ba3
+Content-Disposition: form-data; name="two[item-a]"; filename="bar.png"
+Content-Length: 71
+Content-Type: image/png
+
+?PNG
+
+???
+IHDR??? ??? ?????? ???? IDATxc???51?)?:??????IEND?B`?
+--578de3b0e3c46.2334ba3
+Content-Disposition: form-data; name="three[item][]"; filename="foo.png"
+Content-Length: 71
+Content-Type: image/png
+
+?PNG
+
+???
+IHDR??? ??? ?????? ???? IDATxc???51?)?:??????IEND?B`?
+--578de3b0e3c46.2334ba3
+Content-Disposition: form-data; name="three[item][]"; filename="bar.png"
+Content-Length: 71
+Content-Type: image/png
+
+?PNG
+
+???
+IHDR??? ??? ?????? ???? IDATxc???51?)?:??????IEND?B`?
+--578de3b0e3c46.2334ba3
+Content-Disposition: form-data; name="four[item_a][item_b[]"; filename="foo.png"
+Content-Length: 71
+Content-Type: image/png
+
+?PNG
+
+???
+IHDR??? ??? ?????? ???? IDATxc???51?)?:??????IEND?B`?
+Content-Disposition: form-data; name="four[item_a][item_b[]"; filename="bar.png"
+Content-Length: 71
+Content-Type: image/png
+
+?PNG
+
+???
+IHDR??? ??? ?????? ???? IDATxc???51?)?:??????IEND?B`?
+--578de3b0e3c46.2334ba3
+Content-Type: text/plain
+Content-Disposition: form-data; name="baz"
+Content-Length: 6
+
+string
+--578de3b0e3c46.2334ba3--
+HTTP;
+
+        $stream = fopen('php://memory', 'r+');
+        fwrite($stream, $content);
+
+        // Create the request
+        $request = new Request($params, $stream);
+
+        // Check request object
+        $this->assertEquals($expectedPost,    $request->getPost());
+        $this->assertEquals($stream,          $request->getStdin());
+
+        // Check the PSR server request
+        rewind($stream);
+        $serverRequest = $request->getServerRequest();
+        $this->assertEquals($expectedPost, $serverRequest->getParsedBody());
+        $files = $serverRequest->getUploadedFiles();
+        $this->assertNotEmpty($files['one']);
+        $this->assertCount(2, $files['one']);
+
+        $this->assertNotEmpty($files['two']);
+        $this->assertCount(1, $files['two']);
+        $this->assertNotEmpty($files['two']['item-a']);
+
+        $this->assertNotEmpty($files['three']);
+        $this->assertCount(1, $files['three']);
+        $this->assertCount(2, $files['three']['item']);
+
+        $this->assertNotEmpty($files['four']);
+        $this->assertNotEmpty($files['four']['item_a']);
+        $this->assertNotEmpty($files['four']['item_a']['item_b']);
+        $this->assertCount(2, $files['three']['item_a']['item_b']);
+
+        // Check the HttpFoundation request
+        rewind($stream);
+        $httpFoundationRequest = $request->getHttpFoundationRequest();
+        $this->assertEquals($expectedPost, $httpFoundationRequest->request->all());
+        $this->assertCount(7,              $httpFoundationRequest->files->all());
+
+    }
 }


### PR DESCRIPTION
This is based on #37. I will rebase when it is merged. 

We need to properly support field names like `foo[]` and `foo[bar]`. This PR will add such support. 