### PR TITLE
Make IDE stop complaining about syntax error

### DIFF
--- a/src/Driver/DriverContainer.php
+++ b/src/Driver/DriverContainer.php
@@ -32,7 +32,8 @@ class DriverContainer implements DriverContainerInterface
         }
 
         if (null === $this->drivers[$driver]['object']) {
-            $this->drivers[$driver]['object'] = new $this->drivers[$driver]['classPath']();
+            $class = $this->drivers[$driver]['classPath'];
+            $this->drivers[$driver]['object'] = new $class();
         }
 
         return $this->drivers[$driver]['object'];


### PR DESCRIPTION
PHPStorm was complaining for some reason. 