### PR TITLE
Make classes that implement an interface final

### DIFF
--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Application;
 /**
  * The default implementation of the ApplicationFactoryInterface.
  */
-class ApplicationFactory implements ApplicationFactoryInterface
+final class ApplicationFactory implements ApplicationFactoryInterface
 {
     /**
      * @var DriverContainerInterface

--- a/src/CallbackWrapper.php
+++ b/src/CallbackWrapper.php
@@ -8,7 +8,7 @@ use PHPFastCGI\FastCGIDaemon\Http\RequestInterface;
  * Wraps a callback (such as a closure, function or class and method pair) as an
  * implementation of the kernel interface.
  */
-class CallbackWrapper implements KernelInterface
+final class CallbackWrapper implements KernelInterface
 {
     /**
      * @var callable

--- a/src/Driver/DriverContainer.php
+++ b/src/Driver/DriverContainer.php
@@ -2,7 +2,7 @@
 
 namespace PHPFastCGI\FastCGIDaemon\Driver;
 
-class DriverContainer implements DriverContainerInterface
+final class DriverContainer implements DriverContainerInterface
 {
     /**
      * @var array

--- a/src/Driver/Userland/Connection/StreamSocketConnection.php
+++ b/src/Driver/Userland/Connection/StreamSocketConnection.php
@@ -8,7 +8,7 @@ use PHPFastCGI\FastCGIDaemon\Driver\Userland\Exception\ConnectionException;
  * The default implementation of the ConnectionInterface using stream socket
  * resources.
  */
-class StreamSocketConnection implements ConnectionInterface
+final class StreamSocketConnection implements ConnectionInterface
 {
     /**
      * @var bool

--- a/src/Driver/Userland/Connection/StreamSocketConnectionPool.php
+++ b/src/Driver/Userland/Connection/StreamSocketConnectionPool.php
@@ -6,7 +6,7 @@ namespace PHPFastCGI\FastCGIDaemon\Driver\Userland\Connection;
  * The default implementation of the ConnectionPoolInterface using stream
  * sockets.
  */
-class StreamSocketConnectionPool implements ConnectionPoolInterface
+final class StreamSocketConnectionPool implements ConnectionPoolInterface
 {
     /**
      * @var resource

--- a/src/Driver/Userland/ConnectionHandler/ConnectionHandler.php
+++ b/src/Driver/Userland/ConnectionHandler/ConnectionHandler.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\Response as HttpFoundationResponse;
 /**
  * The default implementation of the ConnectionHandlerInterface.
  */
-class ConnectionHandler implements ConnectionHandlerInterface
+final class ConnectionHandler implements ConnectionHandlerInterface
 {
     const READ_LENGTH = 4096;
 

--- a/src/Driver/Userland/ConnectionHandler/ConnectionHandlerFactory.php
+++ b/src/Driver/Userland/ConnectionHandler/ConnectionHandlerFactory.php
@@ -8,7 +8,7 @@ use PHPFastCGI\FastCGIDaemon\KernelInterface;
 /**
  * The default implementation of the ConnectionHandlerFactoryInterface.
  */
-class ConnectionHandlerFactory implements ConnectionHandlerFactoryInterface
+final class ConnectionHandlerFactory implements ConnectionHandlerFactoryInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Driver/Userland/UserlandDaemon.php
+++ b/src/Driver/Userland/UserlandDaemon.php
@@ -15,7 +15,7 @@ use PHPFastCGI\FastCGIDaemon\KernelInterface;
  * The standard implementation of the DaemonInterface is constructed from a
  * connection pool and a factory class to generate connection handlers.
  */
-class UserlandDaemon implements DaemonInterface
+final class UserlandDaemon implements DaemonInterface
 {
     use DaemonTrait;
 

--- a/src/Driver/Userland/UserlandDaemonFactory.php
+++ b/src/Driver/Userland/UserlandDaemonFactory.php
@@ -12,7 +12,7 @@ use PHPFastCGI\FastCGIDaemon\KernelInterface;
 /**
  * A factory class for instantiating UserlandDaemon objects.
  */
-class UserlandDaemonFactory implements DaemonFactoryInterface
+final class UserlandDaemonFactory implements DaemonFactoryInterface
 {
     /**
      * Create a FastCGI daemon listening on file descriptor using the

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -9,7 +9,7 @@ use Zend\Diactoros\ServerRequestFactory;
 /**
  * The default implementation of the RequestInterface.
  */
-class Request implements RequestInterface
+final class Request implements RequestInterface
 {
     /**
      * @var array


### PR DESCRIPTION
This is highly opinionated. It is easier to remove `final` than adding it.

For reference: https://ocramius.github.io/blog/when-to-declare-classes-final/