### PR TITLE
Adding DaemonFactoryInterface::createDaemonFromStreamSocket

### DIFF
--- a/src/DaemonFactoryInterface.php
+++ b/src/DaemonFactoryInterface.php
@@ -45,5 +45,5 @@ interface DaemonFactoryInterface
      *
      * @return DaemonInterface The FastCGI daemon
      */
-    public function createDaemonFromStreamSocket(KernelInterface $kernel, DaemonOptions $options, int $socket): DaemonInterface;
+    public function createDaemonFromStreamSocket(KernelInterface $kernel, DaemonOptions $options, $socket): DaemonInterface;
 }

--- a/test/Helper/Mocker/MockDaemonFactory.php
+++ b/test/Helper/Mocker/MockDaemonFactory.php
@@ -21,7 +21,7 @@ class MockDaemonFactory implements DaemonFactoryInterface
         return $this->delegateCall('createTcpDaemon', func_get_args());
     }
 
-    public function createDaemonFromStreamSocket(KernelInterface $kernel, DaemonOptions $options, int $socket): DaemonInterface
+    public function createDaemonFromStreamSocket(KernelInterface $kernel, DaemonOptions $options, $socket): DaemonInterface
     {
         return $this->delegateCall('createDaemonFromStreamSocket', func_get_args());
     }


### PR DESCRIPTION
This method was missing from the interface but existed in the implementation. This PR should me merged or `DaemonFactory::createDaemonFromStreamSocket` should be removed. 